### PR TITLE
Deploy to github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main, master, cursor/deploy-to-github-pages-3cba ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,49 @@
+# GitHub Pages Deployment Setup
+
+This repository is now configured to automatically deploy to GitHub Pages using GitHub Actions.
+
+## Automatic Setup Completed ✅
+
+1. **GitHub Actions Workflow**: Created `.github/workflows/deploy.yml` that automatically builds and deploys the site when changes are pushed to main, master, or the current branch.
+
+2. **Static Site Ready**: The project is already configured as a static site using CDN-based React, which is perfect for GitHub Pages.
+
+## Manual Steps Required in GitHub Repository Settings
+
+To complete the GitHub Pages deployment, you need to:
+
+1. **Go to Repository Settings**:
+   - Navigate to https://github.com/Wizumz/Hookr/settings/pages
+
+2. **Configure Pages Source**:
+   - Under "Source", select "GitHub Actions" (not "Deploy from a branch")
+   - This tells GitHub to use the workflow we created instead of trying to build from a branch
+
+3. **Merge the Deployment Branch** (if needed):
+   - Create a pull request to merge `cursor/deploy-to-github-pages-3cba` into your main branch
+   - Or switch your default branch to include the workflow file
+
+## Expected Deployment URL
+
+Once configured, your site will be available at:
+**https://wizumz.github.io/Hookr/**
+
+## How It Works
+
+- The workflow triggers on pushes to main/master branches
+- It uploads the entire repository as a static site artifact
+- GitHub Pages serves the `index.html` file and all assets
+- No build process is needed since you're using CDN-based React
+
+## Monitoring Deployments
+
+- Check the "Actions" tab in your GitHub repository to monitor deployment status
+- Each push will trigger a new deployment automatically
+- Deployments typically take 1-3 minutes to complete
+
+## Troubleshooting
+
+If the site doesn't load properly:
+1. Check that all file paths in `index.html` are relative (they are ✅)
+2. Ensure the GitHub Pages source is set to "GitHub Actions"
+3. Check the Actions tab for any deployment errors


### PR DESCRIPTION
Add GitHub Actions workflow to enable automatic deployment to GitHub Pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9a9f364-2889-4ea3-a6e1-d6e31b1c12ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9a9f364-2889-4ea3-a6e1-d6e31b1c12ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

